### PR TITLE
Extremely tiny documentation fix for impl Proc

### DIFF
--- a/dm/src/proc.rs
+++ b/dm/src/proc.rs
@@ -49,12 +49,14 @@ impl<'a> Proc {
 	///
 	/// # Examples
 	///
-	/// This function function is equivalent to `return do_explode(3)` in DM.
+	/// This function is equivalent to `return do_explode(3)` in DM.
+	/// ```ignore
 	/// #[hook("/proc/my_proc")]
 	/// fn my_proc_hook() -> DMResult {
 	/// 	let proc = Proc::find("/proc/do_explode").unwrap();
 	/// 	proc.call(&[&Value::from(3.0)])
 	/// }
+	/// ```
 	pub fn call(&self, args: &[&Value<'a>]) -> runtime::DMResult<'a> {
 		let mut ret = raw_types::values::Value {
 			tag: raw_types::values::ValueTag::Null,


### PR DESCRIPTION
An extremely tiny documentation fix for `impl Proc`.

Needed the markdown code block.