### PR TITLE
Adds autogenerating rust docs to the GitHub Pages docs branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Generate Docs
+
+on:
+  push:
+    branches: [ master, feature/github-autogen-docs ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # The first job utilizes windows-latest (since auxtools needs windows currently)
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        persist-credentials: false # Necessary.
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable-i686-unknown-linux-gnu
+        target: i686-unknown-linux-gnu
+        override: true
+
+    - name: Install Dependencies
+      run: sudo apt install build-essential g++-multilib
+
+    - name: Build Docs
+      run: cargo doc --no-deps
+
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@3.7.1
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: docs        # The branch the action should deploy to.
+        FOLDER: target/doc  # The folder we deploy to Github Sites.
+        CLEAN: true         # Automatically remove deleted files from the deploy branch.
+        SINGLE_COMMIT: true # Keep only one commit for the docs branch.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest # The first job utilizes windows-latest (since auxtools needs windows currently)
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Generate Docs
 
 on:
   push:
-    branches: [ master, feature/github-autogen-docs ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/dm/src/hooks.cpp
+++ b/dm/src/hooks.cpp
@@ -33,7 +33,6 @@ extern "C" Value LINUX_REGPARM3 call_proc_by_id_original_trampoline(
 	uint32_t unk_1,
 	uint32_t unk_2
 ) {
-	extern CallProcById_Hook_Ptr call_proc_by_id_original;
 	return call_proc_by_id_original(usr, proc_type, proc_id, unk_0, src, args, args_count, unk_1, unk_2);
 }
 


### PR DESCRIPTION
Autogenerated `rust doc --nodeps` on each master push, deployed to the `docs` branch.

Also fixes a compilation error in hooks.cpp