### PR TITLE
Proper 32-bit CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,17 +11,20 @@ env:
 
 jobs:
   build:
-
     runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
+
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: stable-i686-pc-windows-msvc
+        target: i686-pc-windows-msvc
         override: true
+
     - name: Build
       run: cargo build --verbose
+
     - name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
Sets the CI to be 32bit, which it was not before.
Also switches our toolchain to be stable instead of nightly, since that's what auxtools targets now.