### PR TITLE
Added clean exclude for non-generated index.html for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,3 +34,4 @@ jobs:
         FOLDER: target/doc  # The folder we deploy to Github Sites.
         CLEAN: true         # Automatically remove deleted files from the deploy branch.
         SINGLE_COMMIT: true # Keep only one commit for the docs branch.
+        CLEAN_EXCLUDE: '["index.html"]' # Exclude the index from being deleted, since it's not generated. https://github.com/rust-lang/rust/issues/73185


### PR DESCRIPTION
So, turns out `cargo doc` is slightly idiotic and doesn't generate a base .html page to browse the various documented modules. See: https://github.com/rust-lang/cargo/issues/8229

So, the clean now excludes the index.html from being removed. We could also disable clean, but that could potentially lead to some broken docs.
Here's @MCHSL's index.html file, **needs to be manually added** to the docs branch:
```html
<!DOCTYPE HTML>

<meta charset="UTF-8">
<meta http-equiv="refresh" content="1; url=/dm/index.html">

<script>
  window.location.href = "/dm/index.html"
</script>

<title>Page Redirection</title>

<!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
If you are not redirected automatically, follow this <a href='/dm/index.html'>link</a>

```