### PR TITLE
Added a "priority callbacks" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "coarsetime"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cbaaa2e4f75bd7eff165a3d24345a374efddbe0e90be326e62048937e56f65a"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +160,7 @@ name = "dm"
 version = "0.1.0"
 dependencies = [
  "cc",
+ "coarsetime",
  "detour",
  "dm-impl",
  "flume",
@@ -291,7 +303,7 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -705,6 +717,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/dm/Cargo.toml
+++ b/dm/Cargo.toml
@@ -14,6 +14,7 @@ once_cell = "1.4"
 inventory = "0.1"
 lazy_static = "1.4.0"
 flume = "0.9.1"
+coarsetime = "0.1.16"
 
 [dependencies.detour]
 version = "0.7"


### PR DESCRIPTION
A feature I've kinda been jonesin' for. I'm using callbacks for my threaded atmos, but callbacks are too "high priority" for it: they're always run, each and every one, each and every tick. So I've changed the default to one that allows for the behavior I desire: only runs if there's enough time left in the tick, only runs as long as there's enough time left in the tick. You can make one with the old behavior with the new `Callback::new_priority` function. Here's an example of usage:

```dm
#define TICK_REMAINING_MS ((Master.current_ticklimit - TICK_USAGE) * world.tick_lag)

/datum/controller/subsystem/callbacks/fire()
	_process_callbacks_priority()
	if(TICK_CHECK || _process_callbacks(MC_TICK_REMAINING_MS))
		pause()
```