### PR TITLE
Get string id fix

### DIFF
--- a/auxtools/src/raw_types/funcs.cpp
+++ b/auxtools/src/raw_types/funcs.cpp
@@ -144,7 +144,7 @@ extern "C" uint8_t get_string_id(uint32_t *out, const char *data)
 
 	BYOND_TRY
 	{
-		*out = get_string_id_byond(data, 1, 0, 1);
+		*out = get_string_id_byond(data, 0, 0, 1);
 		return 1;
 	}
 	BYOND_CATCH


### PR DESCRIPTION
The param is called `utf8` but is really some sort of i8 where a negative value auto-detects an encoding and 0 is just normal utf-8 (probably).

The 1 was making it leak due to a leaky ansi -> utf8 conversion