### PR TITLE
Fixes a warning regarding cstrings

### DIFF
--- a/auxtools/src/version.rs
+++ b/auxtools/src/version.rs
@@ -27,12 +27,8 @@ pub fn init() -> Result<(), String> {
 
 		unsafe {
 			let mut module = std::ptr::null_mut();
-			if libloaderapi::GetModuleHandleExA(
-				0,
-				CString::new(BYONDCORE).unwrap().as_ptr(),
-				&mut module,
-			) == 0
-			{
+			let core_str = CString::new(BYONDCORE).unwrap();
+			if libloaderapi::GetModuleHandleExA(0, core_str.as_ptr(), &mut module) == 0 {
 				return Err("Couldn't get module handle for BYONDCORE".into());
 			}
 

--- a/debug_server/src/stddef.rs
+++ b/debug_server/src/stddef.rs
@@ -21,12 +21,8 @@ fn stddef_init(_: &DMContext) -> Result<(), String> {
 
 		unsafe {
 			let mut module = std::ptr::null_mut();
-			if libloaderapi::GetModuleHandleExA(
-				0,
-				CString::new(BYONDCORE).unwrap().as_ptr(),
-				&mut module,
-			) == 0
-			{
+			let core_str = CString::new(BYONDCORE).unwrap();
+			if libloaderapi::GetModuleHandleExA(0, core_str.as_ptr(), &mut module) == 0 {
 				return Err("Couldn't get module handle for BYONDCORE".into());
 			}
 


### PR DESCRIPTION
Latest version of Rust says these are no good, so I've fixed them.