### PR TITLE
Makes set_by_id, get_by_id public

### DIFF
--- a/auxtools/src/value.rs
+++ b/auxtools/src/value.rs
@@ -118,7 +118,7 @@ impl Value {
 		}
 	}
 
-	fn get_by_id(&self, name_id: raw_types::strings::StringId) -> DMResult {
+	pub fn get_by_id(&self, name_id: raw_types::strings::StringId) -> DMResult {
 		let mut val = raw_types::values::Value {
 			tag: raw_types::values::ValueTag::Null,
 			data: raw_types::values::ValueData { id: 0 },
@@ -134,7 +134,7 @@ impl Value {
 		}
 	}
 
-	fn set_by_id(
+	pub fn set_by_id(
 		&self,
 		name_id: raw_types::strings::StringId,
 		new_value: raw_types::values::Value,


### PR DESCRIPTION
These two functions are slightly tougher to use than the string-based ones but also:

![image](https://user-images.githubusercontent.com/3927690/104819203-d69f7f80-57e0-11eb-8cec-5d86af8047e8.png)

literally having to get the string ID every time makes it *2.5x* as slow as just using the ID every time. I would like to optimize this.