### PR TITLE
Replaces all the thread local dashmaps with static mut HashMaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,15 +7,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
-name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,8 +52,8 @@ version = "0.1.0"
 dependencies = [
  "auxtools-impl",
  "cc",
- "dashmap",
  "detour",
+ "fxhash",
  "inventory",
  "lazy_static",
  "libc",
@@ -230,28 +221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3776b2bcc4e914db501bb9be9572dd706e344b9eb8f882894f3daa651d281381"
 
 [[package]]
-name = "const-random"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
-dependencies = [
- "getrandom 0.2.2",
- "lazy_static",
- "proc-macro-hack",
- "tiny-keccak",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,12 +246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "ctor"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,19 +256,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "3.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
-dependencies = [
- "ahash",
- "cfg-if 0.1.10",
- "num_cpus",
-]
-
-[[package]]
 name = "debug_server"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "auxtools",
  "bincode",
@@ -470,6 +422,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1467,15 +1428,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]

--- a/auxtools/Cargo.toml
+++ b/auxtools/Cargo.toml
@@ -15,7 +15,7 @@ auxtools-impl = { path = "../auxtools-impl", version = "0.1.0", package = "auxto
 once_cell = "1.4"
 inventory = "0.1"
 lazy_static = "1.4.0"
-dashmap = "3.11.10"
+fxhash = "0.2.1"
 
 [dependencies.detour]
 version = "0.7"

--- a/auxtools/src/byond_ffi.rs
+++ b/auxtools/src/byond_ffi.rs
@@ -34,6 +34,10 @@ use std::{
 
 static EMPTY_STRING: c_char = 0;
 thread_local! {
+	// It is actually theoretically possible for this to be grabbed from another thread--
+	// byond_ffi! functions have nothing stopping them from being called elsewhere,
+	// unlike the static muts we have, which are only referenced from functions
+	// callable only from a byond context (i.e. DIRECTLY from byond)
 	static RETURN_STRING: RefCell<CString> = RefCell::new(CString::default());
 }
 

--- a/auxtools/src/list.rs
+++ b/auxtools/src/list.rs
@@ -56,7 +56,11 @@ impl List {
 		}
 	}
 
-	pub fn set<K: Into<Value>, V: Into<Value>>(&self, index: K, value: V) -> Result<(), runtime::Runtime> {
+	pub fn set<K: Into<Value>, V: Into<Value>>(
+		&self,
+		index: K,
+		value: V,
+	) -> Result<(), runtime::Runtime> {
 		let index = index.into();
 		let value = value.into();
 


### PR DESCRIPTION
DashMap is, internally, a Box<[RwLock<HashMap<K, V, S>>]>, with that internal slice having size num_threads*4. This is highly useful and great... if you're accessing it from more than one thread. Instead, we're accessing it from a thread_local, and not just that, but a thread local which it is an *actual impossibility* to access from any thread other than the main Byond thread without invoking undefined behavior *in the first place*.

To that end, I've made all the thread_locals thereof also raw static muts, which are quite a bit faster. This also replaces _every_ thread local in the codebase which it is actually possible to replace, mind--there's one still left over, but there's no reason not to have that there.

I also replaced a few match chains with proper Option<T> and-map-or function chains, cause I just sorta tend to do this when I see it.