### PR TITLE
Implement logpoints

### DIFF
--- a/debug_server/src/server_types.rs
+++ b/debug_server/src/server_types.rs
@@ -22,6 +22,7 @@ pub enum Request {
 	BreakpointSet {
 		instruction: InstructionRef,
 		condition: Option<String>,
+		log_message: Option<String>
 	},
 	BreakpointUnset {
 		instruction: InstructionRef,


### PR DESCRIPTION
This is implementation of [Logpoints](https://code.visualstudio.com/blogs/2018/07/12/introducing-logpoints-and-auto-attach#_introducing-logpoints), helpful and just nice debugging feature.
Any text in curly braces evaluates like a condition in breakpoints (nested braces are not supported and I don't think is important in DM).

<img src="https://user-images.githubusercontent.com/55196698/140671667-e9b9cfa7-06d4-413c-8a7b-d6248ece6fcb.png" width="600"></img>

