### PR TITLE
Derives Copy and Clone for WeakValue

### DIFF
--- a/auxtools/src/weak_value.rs
+++ b/auxtools/src/weak_value.rs
@@ -49,6 +49,7 @@ fn get_next_id() -> f32 {
 ///		thing.call("callback", &[])?;
 /// }
 /// ```
+#[derive(Copy, Clone)]
 pub struct WeakValue {
 	inner: raw_types::values::Value,
 	id: f32,


### PR DESCRIPTION
Since `raw_types::values::Value` implements `Copy` and `Clone`, and `f32` is a primitive which inherently derives those traits, I see no reason as to why `WeakValue` shouldn't derive them too. This makes working with them significantly easier.