### PR TITLE
Allow returning all matches from sigscan

### DIFF
--- a/auxtools/src/sigscan/windows.rs
+++ b/auxtools/src/sigscan/windows.rs
@@ -53,10 +53,18 @@ impl Scanner {
 	}
 
 	pub fn find(&self, signature: &[Option<u8>]) -> Option<*mut u8> {
+		let all = self.find_all(signature);
+		if all.len() == 1 {
+			return all.into_iter().next();
+		}
+		return None;
+	}
+
+	pub fn find_all(&self, signature: &[Option<u8>]) -> Vec<*mut u8> {
 		let mut data_current = self.data_begin;
 		let data_end = self.data_end;
 		let mut signature_offset = 0;
-		let mut result: Option<*mut u8> = None;
+		let mut result = Vec::new();
 
 		unsafe {
 			while data_current <= data_end {
@@ -64,11 +72,7 @@ impl Scanner {
 					|| signature[signature_offset] == Some(*data_current)
 				{
 					if signature.len() <= signature_offset + 1 {
-						if result.is_some() {
-							// Found two matches.
-							return None;
-						}
-						result = Some(data_current.offset(-(signature_offset as isize)));
+						result.push(data_current.offset(-(signature_offset as isize)));
 						data_current = data_current.offset(-(signature_offset as isize));
 						signature_offset = 0;
 					} else {


### PR DESCRIPTION
This change adds function `find_all` to signature scanner, allowing to get all results from it for further introspection 