### PR TITLE
Some fixes, and updated inventory finally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,24 +752,12 @@ source = "git+https://github.com/willox/SpacemanDMM?branch=fixes#6e6620cabc9e1cb
 
 [[package]]
 name = "inventory"
-version = "0.1.11"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
+checksum = "84344c6e0b90a9e2b6f3f9abe5cc74402684e348df7b32adca28747e0cef091a"
 dependencies = [
  "ctor",
  "ghost",
- "inventory-impl",
-]
-
-[[package]]
-name = "inventory-impl"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/auxtools-impl/src/lib.rs
+++ b/auxtools-impl/src/lib.rs
@@ -95,7 +95,7 @@ pub fn runtime_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 	let inventory_define = quote! {
 		auxtools::inventory::submit!(
-			auxtools::RuntimeHook(#func_name)
+			auxtools::RuntimeErrorHook(#func_name)
 		);
 	};
 

--- a/auxtools-impl/src/lib.rs
+++ b/auxtools-impl/src/lib.rs
@@ -76,7 +76,6 @@ pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 	let inventory_define = quote! {
 		auxtools::inventory::submit!(
-			#![crate = auxtools]
 			#func_type(#func_name)
 		);
 	};
@@ -96,7 +95,6 @@ pub fn runtime_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 	let inventory_define = quote! {
 		auxtools::inventory::submit!(
-			#![crate = auxtools]
 			auxtools::RuntimeHook(#func_name)
 		);
 	};
@@ -116,7 +114,6 @@ pub fn shutdown(_: TokenStream, item: TokenStream) -> TokenStream {
 
 	let inventory_define = quote! {
 		auxtools::inventory::submit!(
-			#![crate = auxtools]
 			auxtools::PartialShutdownFunc(#func_name)
 		);
 	};
@@ -177,19 +174,28 @@ pub fn hook(attr: TokenStream, item: TokenStream) -> TokenStream {
 	}
 
 	let cthook_prelude = match proc {
-		Some(p) => quote! {
-			auxtools::inventory::submit!(
-				#![crate = auxtools]
-				auxtools::CompileTimeHook::new(#p, #func_name)
-			);
-		},
+		Some(Lit::Str(p)) => {
+			quote! {
+				auxtools::inventory::submit!({
+					auxtools::CompileTimeHook{ proc_path: #p, hook: #func_name }
+				});
+			}
+		}
+		Some(other_literal) => {
+			return syn::Error::new(
+				other_literal.span(),
+				"Hook attributes must be a string literal",
+			)
+			.to_compile_error()
+			.into()
+		}
 		None => quote! {},
 	};
 	let signature = quote! {
 		fn #func_name(
 			src: &auxtools::Value,
 			usr: &auxtools::Value,
-			args: &mut Vec<auxtools::Value>,
+			mut args: Vec<auxtools::Value>,
 		) -> auxtools::DMResult
 	};
 
@@ -200,6 +206,7 @@ pub fn hook(attr: TokenStream, item: TokenStream) -> TokenStream {
 		proc_macro2::TokenStream,
 		syn::Token![,],
 	> = syn::punctuated::Punctuated::new();
+
 	for arg in args.iter().map(extract_args) {
 		if let syn::Pat::Ident(p) = &*arg.pat {
 			arg_names.push(p.ident.clone());

--- a/auxtools/Cargo.toml
+++ b/auxtools/Cargo.toml
@@ -13,8 +13,7 @@ cc = "1.0"
 [dependencies]
 auxtools-impl = { path = "../auxtools-impl", version = "0.1.0", package = "auxtools-impl" }
 once_cell = "1.10.0"
-#do not update inventory
-inventory = "0.1"
+inventory = "0.2.3"
 lazy_static = "1.4.0"
 ahash = "0.7.6"
 fxhash = "0.2.1"

--- a/auxtools/src/hooks.rs
+++ b/auxtools/src/hooks.rs
@@ -16,10 +16,9 @@ pub struct CompileTimeHook {
 
 inventory::collect!(CompileTimeHook);
 
-// TODO: This is super deceptively named
 #[doc(hidden)]
-pub struct RuntimeHook(pub fn(&str));
-inventory::collect!(RuntimeHook);
+pub struct RuntimeErrorHook(pub fn(&str));
+inventory::collect!(RuntimeErrorHook);
 
 extern "C" {
 	static mut call_proc_by_id_original: *const c_void;
@@ -126,7 +125,7 @@ impl Proc {
 extern "C" fn on_runtime(error: *const c_char) {
 	let str = unsafe { CStr::from_ptr(error) }.to_string_lossy();
 
-	for func in inventory::iter::<RuntimeHook> {
+	for func in inventory::iter::<RuntimeErrorHook> {
 		func.0(&str);
 	}
 }

--- a/auxtools/src/hooks.rs
+++ b/auxtools/src/hooks.rs
@@ -3,21 +3,15 @@ use super::raw_types;
 use super::value::Value;
 use crate::runtime::DMResult;
 use detour::RawDetour;
+use fxhash::FxHashMap;
 use std::ffi::c_void;
 use std::os::raw::c_char;
 use std::{cell::RefCell, ffi::CStr};
-use fxhash::FxHashMap;
 
 #[doc(hidden)]
 pub struct CompileTimeHook {
 	pub proc_path: &'static str,
 	pub hook: ProcHook,
-}
-
-impl CompileTimeHook {
-	pub fn new(proc_path: &'static str, hook: ProcHook) -> Self {
-		CompileTimeHook { proc_path, hook }
-	}
 }
 
 inventory::collect!(CompileTimeHook);
@@ -89,19 +83,23 @@ pub fn init() -> Result<(), String> {
 	Ok(())
 }
 
-pub type ProcHook = fn(&Value, &Value, &mut Vec<Value>) -> DMResult;
+pub type ProcHook = fn(&Value, &Value, Vec<Value>) -> DMResult;
 
 thread_local! {
-	static PROC_HOOKS: RefCell<FxHashMap<raw_types::procs::ProcId, ProcHook>> = RefCell::new(FxHashMap::default());
+	static PROC_HOOKS: RefCell<FxHashMap<raw_types::procs::ProcId, (ProcHook, String)>> = RefCell::new(FxHashMap::default());
 }
 
-fn hook_by_id(id: raw_types::procs::ProcId, hook: ProcHook) -> Result<(), HookFailure> {
+fn hook_by_id(
+	id: raw_types::procs::ProcId,
+	hook: ProcHook,
+	hook_path: String,
+) -> Result<(), HookFailure> {
 	PROC_HOOKS.with(|h| {
 		let mut map = h.borrow_mut();
 		if map.contains_key(&id) {
 			return Err(HookFailure::AlreadyHooked);
 		} else {
-			map.insert(id, hook);
+			map.insert(id, (hook, hook_path));
 			Ok(())
 		}
 	})
@@ -113,14 +111,14 @@ pub fn clear_hooks() {
 
 pub fn hook<S: Into<String>>(name: S, hook: ProcHook) -> Result<(), HookFailure> {
 	match super::proc::get_proc(name) {
-		Some(p) => hook_by_id(p.id, hook),
+		Some(p) => hook_by_id(p.id, hook, p.path.to_owned()),
 		None => Err(HookFailure::ProcNotFound),
 	}
 }
 
 impl Proc {
 	pub fn hook(&self, func: ProcHook) -> Result<(), HookFailure> {
-		hook_by_id(self.id, func)
+		hook_by_id(self.id, func, self.path.to_owned())
 	}
 }
 
@@ -147,23 +145,20 @@ extern "C" fn call_proc_by_id_hook(
 	_unknown3: u32,
 ) -> u8 {
 	match PROC_HOOKS.with(|h| match h.borrow().get(&proc_id) {
-		Some(hook) => {
-			let src;
-			let usr;
-			let mut args: Vec<Value>;
+		Some((hook, path)) => {
+			let (src, usr, args) = unsafe {
+				(
+					Value::from_raw(src_raw),
+					Value::from_raw(usr_raw),
+					// Taking ownership of args here
+					std::slice::from_raw_parts(args_ptr, num_args)
+						.iter()
+						.map(|v| Value::from_raw_owned(*v))
+						.collect(),
+				)
+			};
 
-			unsafe {
-				src = Value::from_raw(src_raw);
-				usr = Value::from_raw(usr_raw);
-
-				// Taking ownership of args here
-				args = std::slice::from_raw_parts(args_ptr, num_args)
-					.iter()
-					.map(|v| Value::from_raw_owned(*v))
-					.collect();
-			}
-
-			let result = hook(&src, &usr, &mut args);
+			let result = hook(&src, &usr, args);
 
 			match result {
 				Ok(r) => {
@@ -173,10 +168,14 @@ extern "C" fn call_proc_by_id_hook(
 					Some(result_raw)
 				}
 				Err(e) => {
-					// TODO: Some info about the hook would be useful (as the hook is never part of byond's stack, the runtime won't show it.)
 					Proc::find("/proc/auxtools_stack_trace")
 						.unwrap()
-						.call(&[&Value::from_string(e.message.as_str()).unwrap()])
+						.call(&[&Value::from_string(format!(
+							"{} HookPath: {}",
+							e.message.as_str(),
+							path.as_str()
+						))
+						.unwrap()])
 						.unwrap();
 					Some(Value::null().raw)
 				}

--- a/auxtools/src/lib.rs
+++ b/auxtools/src/lib.rs
@@ -25,7 +25,7 @@ mod weak_value;
 use init::{get_init_level, set_init_level, InitLevel};
 
 pub use auxtools_impl::{hook, init, runtime_handler, shutdown};
-pub use hooks::{CompileTimeHook, RuntimeHook};
+pub use hooks::{CompileTimeHook, RuntimeErrorHook};
 pub use init::{FullInitFunc, PartialInitFunc, PartialShutdownFunc};
 pub use list::List;
 pub use proc::Proc;

--- a/auxtools/src/proc.rs
+++ b/auxtools/src/proc.rs
@@ -1,8 +1,8 @@
 use crate::*;
 use ahash::RandomState;
 use fxhash::FxHashMap;
-use std::collections::{HashMap, hash_map::Entry};
 use std::cell::RefCell;
+use std::collections::{hash_map::Entry, HashMap};
 use std::fmt;
 
 //

--- a/auxtools/src/string_intern.rs
+++ b/auxtools/src/string_intern.rs
@@ -16,6 +16,9 @@ macro_rules! byond_string {
 	};
 }
 
+//hack
+unsafe impl Sync for InternedString {}
+
 #[doc(hidden)]
 pub struct InternedString(pub &'static str, pub UnsafeCell<Option<StringRef>>);
 

--- a/debug_server/src/server.rs
+++ b/debug_server/src/server.rs
@@ -11,7 +11,7 @@ use std::{
 	thread::JoinHandle,
 };
 
-use clap::{Command, Arg};
+use clap::{Arg, Command};
 
 use super::server_types::*;
 use auxtools::raw_types::values::{ValueData, ValueTag};
@@ -786,7 +786,7 @@ impl Server {
 							None => "no path provided".to_owned(),
 						},
 
-					Some(("end", _)) => {
+						Some(("end", _)) => {
 							mem_profiler::end();
 							"Memory profiler disabled".to_owned()
 						}

--- a/tests/byond_get/src/main.rs
+++ b/tests/byond_get/src/main.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use clap::{Command, Arg};
+use clap::{Arg, Command};
 
 fn get_zip_url(major: u32, minor: u32) -> reqwest::Url {
 	reqwest::Url::parse(&format!(


### PR DESCRIPTION
- print out the hooked proc's path for runtimes
- errors if hook attribute is not a string literal
- proc hook owns the args vec now instead of referencing it mutably (const requirement)
- run cargo fmt