### PR TITLE
Multiple changes used by tgstation's Auxlua library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ version = "0.1.0"
 dependencies = [
  "auxtools-impl",
  "cc",
+ "ctor",
  "dashmap",
  "detour",
  "inventory",
@@ -286,9 +287,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "ctor"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
  "syn",
@@ -1049,11 +1050,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1375,13 +1376,13 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.67"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1591,6 +1592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,12 +1611,6 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"

--- a/auxtools-impl/src/lib.rs
+++ b/auxtools-impl/src/lib.rs
@@ -129,6 +129,26 @@ pub fn shutdown(_: TokenStream, item: TokenStream) -> TokenStream {
 	code.into()
 }
 
+#[proc_macro_attribute]
+pub fn full_shutdown(_: TokenStream, item: TokenStream) -> TokenStream {
+	let func = syn::parse_macro_input!(item as syn::ItemFn);
+	let func_name = &func.sig.ident;
+
+	let inventory_define = quote! {
+		auxtools::inventory::submit!(
+			#![crate = auxtools]
+			auxtools::FullShutdownFunc(#func_name)
+		);
+	};
+
+	let code = quote! {
+		#func
+		#inventory_define
+	};
+
+	code.into()
+}
+
 /// The `hook` attribute is used to define functions that may be used as proc hooks,
 /// and to optionally hook those procs upon library initialization.
 ///

--- a/auxtools-impl/src/lib.rs
+++ b/auxtools-impl/src/lib.rs
@@ -146,6 +146,19 @@ pub fn full_shutdown(_: TokenStream, item: TokenStream) -> TokenStream {
 	code.into()
 }
 
+/// The `pin_dll!` macro is used to determine whether the dll handle auxtools
+/// takes on Windows is pinned. For reference, a dll with a pinned handle cannot
+/// be unloaded during execution of the host process - termination of the host is
+/// the only way to unload the dll and release the lock on the corresponding file.
+///
+/// This has very limited use cases - for instance, if a .dmb is hosted on a live
+/// server whose Dream Daemon process is kept running between runs, keeping a pinned
+/// handle to the dll will prevent the corresponding file from being updated by
+/// automatic updaters such as tgs. You shouldn't use this unless you very specifically
+/// need it for your particular use case.
+///
+/// Libraries that unpin the dll using this macro should ensure that no spawned threads
+/// are running when calling `auxtools_full_shutdown` from DM, or else Dream Daemon will crash.
 #[proc_macro]
 pub fn pin_dll(attr: TokenStream) -> TokenStream {
 	let flag = syn::parse_macro_input!(attr as syn::LitBool);

--- a/auxtools-impl/src/lib.rs
+++ b/auxtools-impl/src/lib.rs
@@ -149,6 +149,22 @@ pub fn full_shutdown(_: TokenStream, item: TokenStream) -> TokenStream {
 	code.into()
 }
 
+#[proc_macro]
+pub fn pin_dll(attr: TokenStream) -> TokenStream {
+	let flag = syn::parse_macro_input!(attr as syn::LitBool);
+	let code = quote! {
+		use std::sync::atomic::{AtomicBool, Ordering};
+
+		#[auxtools::ctor::ctor]
+		#[cfg(windows)]
+		fn set_pin_dll() {
+			auxtools::PIN_DLL.store(#flag, Ordering::Relaxed);
+		}
+	};
+
+	code.into()
+}
+
 /// The `hook` attribute is used to define functions that may be used as proc hooks,
 /// and to optionally hook those procs upon library initialization.
 ///

--- a/auxtools/Cargo.toml
+++ b/auxtools/Cargo.toml
@@ -16,6 +16,7 @@ once_cell = "1.4"
 inventory = "0.1"
 lazy_static = "1.4.0"
 dashmap = "3.11.10"
+ctor = "0.1.22"
 
 [dependencies.detour]
 version = "0.7"
@@ -26,6 +27,3 @@ winapi = { version = "0.3.9", features = ["winuser", "libloaderapi", "psapi", "p
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-
-[features]
-unpinned-dll = []

--- a/auxtools/Cargo.toml
+++ b/auxtools/Cargo.toml
@@ -26,3 +26,6 @@ winapi = { version = "0.3.9", features = ["winuser", "libloaderapi", "psapi", "p
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[features]
+unpinned-dll = []

--- a/auxtools/src/hooks.rs
+++ b/auxtools/src/hooks.rs
@@ -47,6 +47,19 @@ extern "C" {
 	) -> raw_types::values::Value;
 }
 
+struct Detours {
+	pub runtime_detour: Option<RawDetour>,
+	pub call_proc_detour: Option<RawDetour>
+}
+
+impl Detours {
+	pub fn new() -> Self {
+		Self{ runtime_detour: None, call_proc_detour: None }
+	}
+}
+
+thread_local!(static DETOURS: RefCell<Detours> = RefCell::new(Detours::new()));
+
 pub enum HookFailure {
 	NotInitialized,
 	ProcNotFound,
@@ -75,7 +88,6 @@ pub fn init() -> Result<(), String> {
 
 		runtime_hook.enable().unwrap();
 		runtime_original = std::mem::transmute(runtime_hook.trampoline());
-		std::mem::forget(runtime_hook);
 
 		let call_hook = RawDetour::new(
 			raw_types::funcs::call_proc_by_id_byond as *const (),
@@ -85,9 +97,26 @@ pub fn init() -> Result<(), String> {
 
 		call_hook.enable().unwrap();
 		call_proc_by_id_original = std::mem::transmute(call_hook.trampoline());
-		std::mem::forget(call_hook);
+
+		DETOURS.with(|detours_cell| {
+			let mut detours = detours_cell.borrow_mut();
+			detours.runtime_detour = Some(runtime_hook);
+			detours.call_proc_detour = Some(call_hook);
+		});
 	}
 	Ok(())
+}
+
+pub fn shutdown(){
+	unsafe {
+		DETOURS.with(|detours_cell| {
+			let detours = detours_cell.borrow();
+			let runtime_hook = detours.runtime_detour.as_ref().unwrap();
+			let call_proc_hook = detours.call_proc_detour.as_ref().unwrap();
+			runtime_hook.disable().unwrap();
+			call_proc_hook.disable().unwrap();
+		});
+	}
 }
 
 pub type ProcHook = fn(&Value, &Value, &mut Vec<Value>) -> DMResult;

--- a/auxtools/src/init.rs
+++ b/auxtools/src/init.rs
@@ -31,9 +31,13 @@ pub struct PartialInitFunc(pub InitFunc);
 #[doc(hidden)]
 pub struct PartialShutdownFunc(pub fn());
 
+#[doc(hidden)]
+pub struct FullShutdownFunc(pub fn());
+
 inventory::collect!(FullInitFunc);
 inventory::collect!(PartialInitFunc);
 inventory::collect!(PartialShutdownFunc);
+inventory::collect!(FullShutdownFunc);
 
 pub fn run_full_init() -> Result<(), String> {
 	for func in inventory::iter::<FullInitFunc> {
@@ -53,6 +57,12 @@ pub fn run_partial_init() -> Result<(), String> {
 
 pub fn run_partial_shutdown() {
 	for func in inventory::iter::<PartialShutdownFunc> {
+		func.0();
+	}
+}
+
+pub fn run_full_shutdown() {
+	for func in inventory::iter::<FullShutdownFunc> {
 		func.0();
 	}
 }

--- a/auxtools/src/lib.rs
+++ b/auxtools/src/lib.rs
@@ -462,18 +462,19 @@ byond_ffi_fn! { auxtools_shutdown(_input) {
 } }
 
 byond_ffi_fn! { auxtools_full_shutdown(_input) {
-	init::run_partial_shutdown();
-	string_intern::destroy_interned_strings();
-	bytecode_manager::shutdown();
+	if get_init_level() == InitLevel::None {
+		init::run_partial_shutdown();
+		string_intern::destroy_interned_strings();
+		bytecode_manager::shutdown();
 
-	hooks::clear_hooks();
-	hooks::shutdown();
-	proc::clear_procs();
+		hooks::clear_hooks();
+		proc::clear_procs();
 
-	unsafe {
-		raw_types::funcs::VARIABLE_NAMES = std::ptr::null();
+		unsafe {
+			raw_types::funcs::VARIABLE_NAMES = std::ptr::null();
+		}
 	}
-
+	hooks::shutdown();
 	set_init_level(InitLevel::Full);
 	init::run_full_shutdown();
 

--- a/auxtools/src/lib.rs
+++ b/auxtools/src/lib.rs
@@ -446,6 +446,9 @@ byond_ffi_fn! { auxtools_init(_input) {
 } }
 
 byond_ffi_fn! { auxtools_shutdown(_input) {
+	if get_init_level() != InitLevel::None {
+		Some("FAILED (already shut down)".to_owned())
+	}
 	init::run_partial_shutdown();
 	string_intern::destroy_interned_strings();
 	bytecode_manager::shutdown();
@@ -462,6 +465,9 @@ byond_ffi_fn! { auxtools_shutdown(_input) {
 } }
 
 byond_ffi_fn! { auxtools_full_shutdown(_input) {
+	if get_init_level() == InitLevel::Full {
+		Some("FAILED (already shut down)".to_owned())
+	}
 	if get_init_level() == InitLevel::None {
 		init::run_partial_shutdown();
 		string_intern::destroy_interned_strings();

--- a/auxtools/src/lib.rs
+++ b/auxtools/src/lib.rs
@@ -447,8 +447,8 @@ byond_ffi_fn! { auxtools_init(_input) {
 
 byond_ffi_fn! { auxtools_shutdown(_input) {
 	if get_init_level() != InitLevel::None {
-		Some("FAILED (already shut down)".to_owned())
-	}
+		return Some("FAILED (already shut down)".to_owned())
+	};
 	init::run_partial_shutdown();
 	string_intern::destroy_interned_strings();
 	bytecode_manager::shutdown();
@@ -466,8 +466,8 @@ byond_ffi_fn! { auxtools_shutdown(_input) {
 
 byond_ffi_fn! { auxtools_full_shutdown(_input) {
 	if get_init_level() == InitLevel::Full {
-		Some("FAILED (already shut down)".to_owned())
-	}
+		return Some("FAILED (already shut down)".to_owned())
+	};
 	if get_init_level() == InitLevel::None {
 		init::run_partial_shutdown();
 		string_intern::destroy_interned_strings();


### PR DESCRIPTION
This PR adds the following:
- The `pin_dll!` macro, which allows library users to specify that, on Windows builds, the dll handle auxtools takes should *not* be pinned. The documentation specifies that there are very few use cases for not pinning the dll, and that caution should be taken when deciding not to pin the dll.
- The `auxtools_full_shutdown` FFI function and corresponding `full_shutdown` attribute. Calling `auxtools_full_shutdown` will, in addition to the standard shutdown sequence, uninstall the proc and runtime hooks, then call every function with the `full_shutdown` attribute. Additionally, on Windows, if the `pin_dll!` macro was used to specify the dll shouldn't be pinned, `FreeLibrary` will be called, unloading the dll once all other handles, including the one created by BYOND itself, are released.
- Redundant calls to `auxtools_shutdown` and `auxtools_full_shutdown` will fail instead of crashing.