### PR TITLE
Adds support for args, contents, vis_contents, and vis_locs lists

### DIFF
--- a/auxtools/src/list.rs
+++ b/auxtools/src/list.rs
@@ -112,6 +112,7 @@ impl List {
 			| raw_types::values::ValueTag::MobContents
 			| raw_types::values::ValueTag::TurfContents
 			| raw_types::values::ValueTag::AreaContents
+			| raw_types::values::ValueTag::WorldContents
 			| raw_types::values::ValueTag::ObjContents
 			| raw_types::values::ValueTag::MobVars
 			| raw_types::values::ValueTag::ObjVars

--- a/auxtools/src/list.rs
+++ b/auxtools/src/list.rs
@@ -108,6 +108,7 @@ impl List {
 	pub fn is_list(value: &Value) -> bool {
 		match value.raw.tag {
 			raw_types::values::ValueTag::List
+			| raw_types::values::ValueTag::ArgList
 			| raw_types::values::ValueTag::MobVars
 			| raw_types::values::ValueTag::ObjVars
 			| raw_types::values::ValueTag::TurfVars

--- a/auxtools/src/list.rs
+++ b/auxtools/src/list.rs
@@ -109,6 +109,10 @@ impl List {
 		match value.raw.tag {
 			raw_types::values::ValueTag::List
 			| raw_types::values::ValueTag::ArgList
+			| raw_types::values::ValueTag::MobContents
+			| raw_types::values::ValueTag::TurfContents
+			| raw_types::values::ValueTag::AreaContents
+			| raw_types::values::ValueTag::ObjContents
 			| raw_types::values::ValueTag::MobVars
 			| raw_types::values::ValueTag::ObjVars
 			| raw_types::values::ValueTag::TurfVars
@@ -124,6 +128,12 @@ impl List {
 			| raw_types::values::ValueTag::AreaOverlays
 			| raw_types::values::ValueTag::AreaUnderlays
 			| raw_types::values::ValueTag::ImageVars
+			| raw_types::values::ValueTag::TurfVisContents
+			| raw_types::values::ValueTag::ObjVisContents
+			| raw_types::values::ValueTag::MobVisContents
+			| raw_types::values::ValueTag::TurfVisLocs
+			| raw_types::values::ValueTag::ObjVisLocs
+			| raw_types::values::ValueTag::MobVisLocs
 			| raw_types::values::ValueTag::WorldVars
 			| raw_types::values::ValueTag::GlobalVars => true,
 			_ => false,

--- a/auxtools/src/list.rs
+++ b/auxtools/src/list.rs
@@ -127,10 +127,13 @@ impl List {
 			| raw_types::values::ValueTag::TurfUnderlays
 			| raw_types::values::ValueTag::AreaOverlays
 			| raw_types::values::ValueTag::AreaUnderlays
+			| raw_types::values::ValueTag::ImageOverlays
+			| raw_types::values::ValueTag::ImageUnderlays
 			| raw_types::values::ValueTag::ImageVars
 			| raw_types::values::ValueTag::TurfVisContents
 			| raw_types::values::ValueTag::ObjVisContents
 			| raw_types::values::ValueTag::MobVisContents
+			| raw_types::values::ValueTag::ImageVisContents
 			| raw_types::values::ValueTag::TurfVisLocs
 			| raw_types::values::ValueTag::ObjVisLocs
 			| raw_types::values::ValueTag::MobVisLocs

--- a/auxtools/src/raw_types/values.rs
+++ b/auxtools/src/raw_types/values.rs
@@ -30,6 +30,7 @@ pub enum ValueTag {
 	MobContents = 0x17,
 	TurfContents = 0x18,
 	AreaContents = 0x19,
+	WorldContents = 0x1A,
 	ObjContents = 0x1C,
 	MobVars = 0x2C,
 	ObjVars = 0x2D,

--- a/auxtools/src/raw_types/values.rs
+++ b/auxtools/src/raw_types/values.rs
@@ -27,6 +27,10 @@ pub enum ValueTag {
 	// Lists
 	List = 0x0F,
 	ArgList = 0x10,
+	MobContents = 0x17,
+	TurfContents = 0x18,
+	AreaContents = 0x19,
+	ObjContents = 0x1C,
 	MobVars = 0x2C,
 	ObjVars = 0x2D,
 	TurfVars = 0x2E,
@@ -42,6 +46,12 @@ pub enum ValueTag {
 	AreaOverlays = 0x38,
 	AreaUnderlays = 0x39,
 	ImageVars = 0x42,
+	TurfVisContents = 0x4B,
+	ObjVisContents = 0x4C,
+	MobVisContents = 0x4D,
+	TurfVisLocs = 0x4E,
+	ObjVisLocs = 0x4F,
+	MobVisLocs = 0x50,
 	WorldVars = 0x51,
 	GlobalVars = 0x52,
 

--- a/auxtools/src/raw_types/values.rs
+++ b/auxtools/src/raw_types/values.rs
@@ -26,6 +26,7 @@ pub enum ValueTag {
 
 	// Lists
 	List = 0x0F,
+	ArgList = 0x10,
 	MobVars = 0x2C,
 	ObjVars = 0x2D,
 	TurfVars = 0x2E,

--- a/auxtools/src/raw_types/values.rs
+++ b/auxtools/src/raw_types/values.rs
@@ -45,6 +45,8 @@ pub enum ValueTag {
 	TurfUnderlays = 0x37,
 	AreaOverlays = 0x38,
 	AreaUnderlays = 0x39,
+	ImageOverlays = 0x40,
+	ImageUnderlays = 0x41,
 	ImageVars = 0x42,
 	TurfVisContents = 0x4B,
 	ObjVisContents = 0x4C,
@@ -54,6 +56,7 @@ pub enum ValueTag {
 	MobVisLocs = 0x50,
 	WorldVars = 0x51,
 	GlobalVars = 0x52,
+	ImageVisContents = 0x54,
 
 	Datum = 0x21,
 	SaveFile = 0x23,


### PR DESCRIPTION
I discovered that `args` uses a raw tag `0x10` that is different from regular lists `0x0F`. Just these little changes add the ability to use lists passed in as `args` in auxtools (e.g. `auxtools_hook(args)`). Seemed to work fine when I tested it in auxlua, but feel free to subject it to more rigorous testing if you want.

Edit: Also adds support to the other list types.