### PR TITLE
Fix a warning in the linux build

### DIFF
--- a/auxtools/src/version.rs
+++ b/auxtools/src/version.rs
@@ -59,7 +59,8 @@ pub fn init() -> Result<(), String> {
 		use libc::{dlopen, dlsym, RTLD_LAZY};
 
 		unsafe {
-			let module = dlopen(CString::new(BYONDCORE).unwrap().as_ptr(), RTLD_LAZY);
+			let byond_core_str = CString::new(BYONDCORE).unwrap();
+			let module = dlopen(byond_core_str.as_ptr(), RTLD_LAZY);
 			if module.is_null() {
 				return Err("Couldn't get module handle for BYONDCORE".into());
 			}

--- a/debug_server/src/ckey_override.rs
+++ b/debug_server/src/ckey_override.rs
@@ -7,15 +7,17 @@ static mut STRING_PTR: *mut *const c_char = std::ptr::null_mut();
 
 #[init(full)]
 fn ckey_override_init() -> Result<(), String> {
-	let byondcore = sigscan::Scanner::for_module(BYONDCORE).unwrap();
-
-	// This feature soft-fails
 	#[cfg(windows)]
-	if let Some(ptr) = byondcore.find(signature!(
-		"68 ?? ?? ?? ?? 50 E8 ?? ?? ?? ?? 83 C4 0C 8D 8D ?? ?? ?? ?? E8 ?? ?? ?? ?? 8B 85 ?? ?? ?? ??"
-	)) {
-		unsafe {
-			STRING_PTR = ptr.add(1) as *mut *const c_char;
+	{
+		let byondcore = sigscan::Scanner::for_module(BYONDCORE).unwrap();
+
+		// This feature soft-fails
+		if let Some(ptr) = byondcore.find(signature!(
+			"68 ?? ?? ?? ?? 50 E8 ?? ?? ?? ?? 83 C4 0C 8D 8D ?? ?? ?? ?? E8 ?? ?? ?? ?? 8B 85 ?? ?? ?? ??"
+		)) {
+			unsafe {
+				STRING_PTR = ptr.add(1) as *mut *const c_char;
+			}
 		}
 	}
 

--- a/debug_server/src/stddef.rs
+++ b/debug_server/src/stddef.rs
@@ -41,7 +41,8 @@ fn stddef_init() -> Result<(), String> {
 		use libc::{dlopen, dlsym, RTLD_LAZY};
 
 		unsafe {
-			let module = dlopen(CString::new(BYONDCORE).unwrap().as_ptr(), RTLD_LAZY);
+			let byond_core_str = CString::new(BYONDCORE).unwrap();
+			let module = dlopen(byond_core_str.as_ptr(), RTLD_LAZY);
 			if module.is_null() {
 				return Err("Couldn't get module handle for BYONDCORE".into());
 			}


### PR DESCRIPTION
```
warning: getting the inner pointer of a temporary `CString`
  --> auxtools/src/version.rs:62:57
   |
62 |             let module = dlopen(CString::new(BYONDCORE).unwrap().as_ptr(), RTLD_LAZY);
   |                                 -------------------------------- ^^^^^^ this pointer will be invalid
   |                                 |
   |                                 this `CString` is deallocated at the end of the statement, bind it to a variable to extend its lifetime
   |
   = note: pointers do not have a lifetime; when calling `as_ptr` the `CString` will be deallocated at the end of the statement because nothing is referencing it as far as the type system is concerned
   = help: for more information, see https://doc.rust-lang.org/reference/destructors.html
   = note: `#[warn(temporary_cstring_as_ptr)]` on by default

warning: `auxtools` (lib) generated 1 warning
```