### PR TITLE
[SEMI-FUNCTIONAL] 1626 Support

### DIFF
--- a/auxtools/src/lib.rs
+++ b/auxtools/src/lib.rs
@@ -50,7 +50,10 @@ extern crate winapi;
 pub const BYONDCORE: &str = "byondcore.dll";
 #[cfg(windows)]
 signatures! {
-	get_proc_array_entry => universal_signature!(call, "E8 ?? ?? ?? ?? 8B C8 8D 45 ?? 6A 01 50 FF 76 ?? 8A 46 ?? FF 76 ?? FE C0"),
+	get_proc_array_entry => version_dependent_signature!(
+		1625.. => (call, "E8 ? ? ? ? 8B 4D ? 8B D0 83 C4 04"),
+		..1625 => (call, "E8 ?? ?? ?? ?? 8B C8 8D 45 ?? 6A 01 50 FF 76 ?? 8A 46 ?? FF 76 ?? FE C0")
+	),
 	get_string_id => universal_signature!("55 8B EC 8B 45 ?? 83 EC ?? 53 56 8B 35 ?? ?? ?? ?? 57 85 C0 75 ?? 68 ?? ?? ?? ??"),
 	call_proc_by_id => version_dependent_signature!(
 		1602.. => "55 8B EC 81 EC 98 00 00 00 A1 ?? ?? ?? ?? 33 C5 89 45 FC 8B 55",


### PR DESCRIPTION
So, Lummox's changes to fix the underscore proc names issue in 1625 changed the signature for `get_proc_array_entry`.

Getting procs themselves seems to work (at least tg-based code seems to think the debugger is present), but line offsets do not work anymore, and I am entirely clueless to how to get those to work.

Auxtools seems to load happily enough on my end otherwise, but I have no clue how to open this in a debugger for proper looking, so I can't say for certain.

![image](https://github.com/willox/auxtools/assets/106692773/a4cf73f9-56d9-486a-976e-0b72f4cc0ceb)
(TG throws a runtime sometime before loading config if auxtools didn't hook in)