### PR TITLE
Fix debugger arguments on BYOND 516 (while keeping 515 support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "debug_server"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "auxtools",
  "bincode",

--- a/auxtools/src/debug.rs
+++ b/auxtools/src/debug.rs
@@ -38,10 +38,10 @@ impl StackFrame {
 
 		// Make sure to handle arguments/locals with no names (when there are more
 		// values than names)
-		let args = (0..(*instance).args_count)
+		let args = (0..(*instance).args_count())
 			.map(|i| {
 				let name = param_names.get(i as usize).cloned();
-				(name, Value::from_raw(*((*instance).args).add(i as usize)))
+				(name, Value::from_raw(*((*instance).args()).add(i as usize)))
 			})
 			.collect();
 
@@ -87,9 +87,9 @@ enum CallStackKind {
 }
 
 impl Default for CallStacks {
-    fn default() -> Self {
-        Self::new()
-    }
+	fn default() -> Self {
+		Self::new()
+	}
 }
 
 impl CallStacks {

--- a/auxtools/src/raw_types/procs.rs
+++ b/auxtools/src/raw_types/procs.rs
@@ -115,10 +115,93 @@ pub struct ProcInstance {
 	argslist_idx: values::ValueData,
 	unk_1: u32,
 	unk_2: u32,
-	pub args_count: u32,
-	pub args: *mut values::Value,
+	inner: ProcInstanceInner
+}
+
+impl ProcInstance {
+	#[inline(never)]
+	fn args_count_pre516(this: &Self) -> u32 {
+		unsafe { this.inner.pre516.args_count }
+	}
+
+	#[inline(never)]
+	fn args_count_post516(this: &Self) -> u32 {
+		unsafe { this.inner.post516.args_count }
+	}
+
+	pub fn args_count(&self) -> u32 {
+		static REDIRECT: OnceLock<fn(&ProcInstance) -> u32> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match crate::version::BYOND_VERSION_MAJOR {
+				..516 => Self::args_count_pre516,
+				_ => Self::args_count_post516
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn args_pre516(this: &Self) -> *mut values::Value {
+		unsafe { this.inner.pre516.args }
+	}
+
+	#[inline(never)]
+	fn args_post516(this: &Self) -> *mut values::Value {
+		unsafe { this.inner.post516.args }
+	}
+
+	pub fn args(&self) -> *mut values::Value {
+		static REDIRECT: OnceLock<fn(&ProcInstance) -> *mut values::Value> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match crate::version::BYOND_VERSION_MAJOR {
+				..516 => Self::args_pre516,
+				_ => Self::args_post516
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn time_to_resume_pre516(this: &Self) -> u32 {
+		unsafe { this.inner.pre516.time_to_resume }
+	}
+
+	#[inline(never)]
+	fn time_to_resume_post516(this: &Self) -> u32 {
+		unsafe { this.inner.post516.time_to_resume }
+	}
+
+	pub fn time_to_resume(&self) -> u32 {
+		static REDIRECT: OnceLock<fn(&ProcInstance) -> u32> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match crate::version::BYOND_VERSION_MAJOR {
+				..516 => Self::time_to_resume_pre516,
+				_ => Self::time_to_resume_post516
+			}
+		})(self)
+	}
+}
+#[repr(C)]
+union ProcInstanceInner {
+	pre516: ProcInstanceInnerPre516,
+	post516: ProcInstanceInnerPost516
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct ProcInstanceInnerPre516 {
+	args_count: u32,
+	args: *mut values::Value,
 	unk_3: [u8; 0x58],
-	pub time_to_resume: u32
+	time_to_resume: u32
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ProcInstanceInnerPost516 {
+	unk_3: u32,
+	args_count: u32,
+	args: *mut values::Value,
+	unk_4: [u8; 0x58],
+	time_to_resume: u32
 }
 
 #[repr(C)]

--- a/debug_server/Cargo.toml
+++ b/debug_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debug_server"
-version = "2.3.4"
+version = "2.3.5"
 publish = false
 authors.workspace = true
 edition.workspace = true

--- a/debug_server/src/server.rs
+++ b/debug_server/src/server.rs
@@ -855,7 +855,7 @@ impl Server {
 									(*instance).src = value.raw;
 								}
 								ArgType::Arg(idx) => {
-									let args = (*instance).args;
+									let args = (*instance).args();
 									let arg = args.add(*idx as usize);
 									let _ = Value::from_raw_owned(*arg);
 									(*arg) = value.raw;


### PR DESCRIPTION
this converts the last part of `auxtools::raw_types::ProcInstance` to a union, for pre and post 516, and adds getters for the parts contained in the union (`args_count`, `args`, and `time_to_resume`), due to an extra entry being added, presumably related to the new callee/caller stuff. same way as was done with `auxtools::raw_types::ProcMetadata` for pre and post 515.1630

for now support for callee/caller isn't implemented - this just keeps existing functionality working on both 515 and 516.

also incremented the debug server version to 2.3.5

![2025-03-26 (1743024880) ~ Code](https://github.com/user-attachments/assets/3970267e-43e7-4429-993a-cd384890d970)
![2025-03-26 (1743025073) ~ Code](https://github.com/user-attachments/assets/d0558b22-b6b7-4c06-b612-8836b2d0e2d3)
