### PR TITLE
Fix latest rust build, 1688+ support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,12 +201,12 @@ dependencies = [
  "cc",
  "ctor",
  "dashmap",
- "detour",
  "fxhash",
  "inventory",
  "lazy_static",
  "libc",
  "once_cell",
+ "retour",
  "winapi",
 ]
 
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "builtins-proc-macro"
 version = "0.0.0"
-source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.9#181067efd1e939e9ca83e71460a95a39a4cb3156"
+source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.10#c1101fb3ad7971f3d19d6b81911fbd94d98fbad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -660,12 +660,12 @@ dependencies = [
  "auxtools",
  "bincode",
  "clap 3.2.25",
- "detour",
  "dmasm",
  "instruction_hooking",
  "lazy_static",
  "libc",
- "region 3.0.2",
+ "region",
+ "retour",
  "serde",
  "winapi",
 ]
@@ -728,22 +728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "detour"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c83fabcc3bc336e19320c13576ea708a15deec201d6b879b7ad1b92734d7b9"
-dependencies = [
- "cfg-if",
- "generic-array",
- "lazy_static",
- "libc",
- "libudis86-sys",
- "mmap-fixed",
- "region 2.2.0",
- "slice-pool",
-]
-
-[[package]]
 name = "deunicode"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,7 +758,7 @@ dependencies = [
 [[package]]
 name = "dmasm"
 version = "0.1.0"
-source = "git+https://github.com/willox/dmasm?tag=515-support#a374671978c2383506d9fb27da0c86e41482a595"
+source = "git+https://github.com/willox/dmasm#027acbb24f789a9a32f4568be0b094a40650f91f"
 dependencies = [
  "bitflags 2.6.0",
  "dreammaker",
@@ -784,16 +768,16 @@ dependencies = [
 [[package]]
 name = "dreammaker"
 version = "0.1.0"
-source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.9#181067efd1e939e9ca83e71460a95a39a4cb3156"
+source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.10#c1101fb3ad7971f3d19d6b81911fbd94d98fbad4"
 dependencies = [
- "ahash",
  "bitflags 1.3.2",
  "builtins-proc-macro",
  "color_space",
  "derivative",
+ "foldhash",
  "get-size",
  "get-size-derive",
- "indexmap 1.9.3",
+ "indexmap 2.7.0",
  "interval-tree",
  "lodepng",
  "ordered-float",
@@ -857,6 +841,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1270,6 +1260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced-x86"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c447cff8c7f384a7d4f741cfcff32f75f3ad02b406432e8d6c878d56b1edf6b"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,9 +1467,9 @@ version = "1.0.0"
 dependencies = [
  "auxtools",
  "cc",
- "detour",
  "dmasm",
  "libc",
+ "retour",
  "symbolic-common",
  "symbolic-demangle",
  "winapi",
@@ -1485,7 +1484,7 @@ checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 [[package]]
 name = "interval-tree"
 version = "0.8.0"
-source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.9#181067efd1e939e9ca83e71460a95a39a4cb3156"
+source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.10#c1101fb3ad7971f3d19d6b81911fbd94d98fbad4"
 
 [[package]]
 name = "inventory"
@@ -1550,16 +1549,6 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
-name = "libudis86-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139bbf9ddb1bfc90c1ac64dd2923d9c957cd433cee7315c018125d72ab08a6b0"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "libz-sys"
@@ -1629,15 +1618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,10 +1684,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mmap-fixed"
-version = "0.1.6"
+name = "mmap-fixed-fixed"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b701cb868ec661212780d23d04d3f70722aed2f1d12bd46e40bad16e35fd480"
+checksum = "0681853891801e4763dc252e843672faf32bcfee27a0aa3b19733902af450acc"
 dependencies = [
  "libc",
  "winapi",
@@ -2211,18 +2191,6 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "region"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "mach",
- "winapi",
-]
-
-[[package]]
-name = "region"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
@@ -2275,6 +2243,22 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-registry",
+]
+
+[[package]]
+name = "retour"
+version = "0.4.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead4bc8e12d553ff70769c5f5c21f5f4f0e73c0018068a6bb5a3d7d3b9e57ec7"
+dependencies = [
+ "cfg-if",
+ "generic-array",
+ "iced-x86",
+ "libc",
+ "mmap-fixed-fixed",
+ "once_cell",
+ "region",
+ "slice-pool2",
 ]
 
 [[package]]
@@ -2560,10 +2544,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "slice-pool"
-version = "0.4.1"
+name = "slice-pool2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733fc6e5f1bd3a8136f842c9bdea4e5f17c910c2fcc98c90c3aa7604ef5e2e7a"
+checksum = "7a3d689654af89bdfeba29a914ab6ac0236d382eb3b764f7454dde052f2821f8"
 
 [[package]]
 name = "slug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ version = "0.1.0"
 
 [workspace.dependencies]
 lazy_static = "1"
-detour = { version = "0.8", default-features = false }
-dmasm = { git = "https://github.com/willox/dmasm", tag = "515-support" }
+retour = { version = "=0.4.0-alpha.4", default-features = false }
+dmasm = { git = "https://github.com/willox/dmasm" }
 
 [workspace.lints.rust]
 static_mut_refs = "allow"

--- a/auxcov/src/codecov.rs
+++ b/auxcov/src/codecov.rs
@@ -119,13 +119,13 @@ impl Tracker {
 
 	// returns true if we need to pause
 	pub fn process_dbg_line(&mut self, ctx: &raw_types::procs::ExecutionContext, proc_instance: &raw_types::procs::ProcInstance) {
-		if ctx.line == 0 || !ctx.filename.valid() {
+		if ctx.line() == 0 || !ctx.filename().valid() {
 			return;
 		}
 
-		let filename_id = ctx.filename;
+		let filename_id = ctx.filename();
 		let proc_map_index = proc_instance.proc.0 as usize;
-		let line = ctx.line as usize;
+		let line = ctx.line() as usize;
 
 		let mut known_file_name: Option<String> = None;
 		for context in &mut self.contexts {
@@ -206,7 +206,7 @@ impl InstructionHook for Tracker {
 		let proc_instance_ref;
 		unsafe {
 			ctx_ref = &*ctx;
-			proc_instance_ref = &*ctx_ref.proc_instance;
+			proc_instance_ref = &*ctx_ref.proc_instance();
 		}
 
 		self.process_dbg_line(ctx_ref, proc_instance_ref);

--- a/auxtools/Cargo.toml
+++ b/auxtools/Cargo.toml
@@ -23,7 +23,7 @@ dashmap = "6"
 ahash = "0.8"
 fxhash = "0.2"
 ctor = "0.2"
-detour = { workspace = true }
+retour = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winuser", "libloaderapi", "psapi", "processthreadsapi"] }

--- a/auxtools/src/bytecode_manager.rs
+++ b/auxtools/src/bytecode_manager.rs
@@ -33,7 +33,7 @@ pub fn init() {
 fn get_active_bytecode_ptrs() -> HashSet<*mut u32> {
 	fn visit(dst: &mut HashSet<*mut u32>, frames: Vec<debug::StackFrame>) {
 		for frame in frames {
-			let ptr = unsafe { (*frame.context).bytecode };
+			let ptr = unsafe { (*frame.context).bytecode() };
 
 			dst.insert(ptr);
 		}

--- a/auxtools/src/debug.rs
+++ b/auxtools/src/debug.rs
@@ -25,16 +25,16 @@ pub struct CallStacks {
 
 impl StackFrame {
 	unsafe fn from_context(context: *mut procs::ExecutionContext) -> StackFrame {
-		let instance = (*context).proc_instance;
+		let instance = (*context).proc_instance();
 
 		let proc = Proc::from_id((*instance).proc).unwrap();
-		let offset = (*context).bytecode_offset;
+		let offset = (*context).bytecode_offset();
 		let param_names = proc.parameter_names();
 		let local_names = proc.local_names();
 
 		let usr = Value::from_raw((*instance).usr);
 		let src = Value::from_raw((*instance).src);
-		let dot = Value::from_raw((*context).dot);
+		let dot = Value::from_raw((*context).dot());
 
 		// Make sure to handle arguments/locals with no names (when there are more
 		// values than names)
@@ -45,11 +45,11 @@ impl StackFrame {
 			})
 			.collect();
 
-		let locals = (0..(*context).locals_count)
+		let locals = (0..(*context).locals_count())
 			.map(|i| {
 				(
 					local_names.get(i as usize).unwrap().clone(),
-					Value::from_raw(*((*context).locals).add(i as usize))
+					Value::from_raw(*((*context).locals()).add(i as usize))
 				)
 			})
 			.collect();
@@ -57,9 +57,9 @@ impl StackFrame {
 		// Only populate the line number if we've got a file-name
 		let mut file_name = None;
 		let mut line_number = None;
-		if (*context).filename.valid() {
-			file_name = Some(StringRef::from_id((*context).filename));
-			line_number = Some((*context).line);
+		if (*context).filename().valid() {
+			file_name = Some(StringRef::from_id((*context).filename()));
+			line_number = Some((*context).line());
 		}
 
 		// TODO: When set this? For all sleepers?
@@ -125,7 +125,7 @@ impl CallStacks {
 
 			unsafe {
 				frames.push(StackFrame::from_context(context));
-				context = (*context).parent_context;
+				context = (*context).parent_context();
 			}
 		}
 

--- a/auxtools/src/hooks.rs
+++ b/auxtools/src/hooks.rs
@@ -4,8 +4,8 @@ use std::{
 	os::raw::c_char
 };
 
-use detour::RawDetour;
 use fxhash::FxHashMap;
+use retour::RawDetour;
 
 use super::{proc::Proc, raw_types, value::Value};
 use crate::runtime::DMResult;

--- a/auxtools/src/raw_types/procs.rs
+++ b/auxtools/src/raw_types/procs.rs
@@ -205,7 +205,251 @@ pub struct ProcInstanceInnerPost516 {
 }
 
 #[repr(C)]
-pub struct ExecutionContext {
+pub union ExecutionContext {
+	pub pre1668: ExecutionContextPre1668,
+	pub post1668: ExecutionContextPost1668,
+}
+
+impl ExecutionContext {
+	pub fn proc_instance(&self) -> *mut ProcInstance {
+		static REDIRECT: OnceLock<fn(&ExecutionContext) -> *mut ProcInstance> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match (crate::version::BYOND_VERSION_MAJOR, crate::version::BYOND_VERSION_MINOR) {
+				(..=515, _) | (516, ..=1667) => Self::proc_instance_pre1668,
+				_ => Self::proc_instance_post1668,
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn proc_instance_pre1668(this: &Self) -> *mut ProcInstance {
+		unsafe { this.pre1668.proc_instance }
+	}
+
+	#[inline(never)]
+	fn proc_instance_post1668(this: &Self) -> *mut ProcInstance {
+		unsafe { this.post1668.proc_instance }
+	}
+
+	pub fn parent_context(&self) -> *mut ExecutionContext {
+		static REDIRECT: OnceLock<fn(&ExecutionContext) -> *mut ExecutionContext> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match (crate::version::BYOND_VERSION_MAJOR, crate::version::BYOND_VERSION_MINOR) {
+				(..=515, _) | (516, ..=1667) => Self::parent_context_pre1668,
+				_ => Self::parent_context_post1668,
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn parent_context_pre1668(this: &Self) -> *mut ExecutionContext {
+		unsafe { this.pre1668.parent_context }
+	}
+
+	#[inline(never)]
+	fn parent_context_post1668(this: &Self) -> *mut ExecutionContext {
+		unsafe { this.post1668.parent_context }
+	}
+
+	pub fn filename(&self) -> strings::StringId {
+		static REDIRECT: OnceLock<fn(&ExecutionContext) -> strings::StringId> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match (crate::version::BYOND_VERSION_MAJOR, crate::version::BYOND_VERSION_MINOR) {
+				(..=515, _) | (516, ..=1667) => Self::filename_pre1668,
+				_ => Self::filename_post1668,
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn filename_pre1668(this: &Self) -> strings::StringId {
+		unsafe { this.pre1668.filename }
+	}
+
+	#[inline(never)]
+	fn filename_post1668(this: &Self) -> strings::StringId {
+		unsafe { this.post1668.filename }
+	}
+
+	pub fn line(&self) -> u32 {
+		static REDIRECT: OnceLock<fn(&ExecutionContext) -> u32> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match (crate::version::BYOND_VERSION_MAJOR, crate::version::BYOND_VERSION_MINOR) {
+				(..=515, _) | (516, ..=1667) => Self::line_pre1668,
+				_ => Self::line_post1668,
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn line_pre1668(this: &Self) -> u32 {
+		unsafe { this.pre1668.line }
+	}
+
+	#[inline(never)]
+	fn line_post1668(this: &Self) -> u32 {
+		unsafe { this.post1668.line }
+	}
+
+	pub fn bytecode(&self) -> *mut u32 {
+		static REDIRECT: OnceLock<fn(&ExecutionContext) -> *mut u32> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match (crate::version::BYOND_VERSION_MAJOR, crate::version::BYOND_VERSION_MINOR) {
+				(..=515, _) | (516, ..=1667) => Self::bytecode_pre1668,
+				_ => Self::bytecode_post1668,
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn bytecode_pre1668(this: &Self) -> *mut u32 {
+		unsafe { this.pre1668.bytecode }
+	}
+
+	#[inline(never)]
+	fn bytecode_post1668(this: &Self) -> *mut u32 {
+		unsafe { this.post1668.bytecode }
+	}
+
+	pub fn bytecode_offset(&self) -> u16 {
+		static REDIRECT: OnceLock<fn(&ExecutionContext) -> u16> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match (crate::version::BYOND_VERSION_MAJOR, crate::version::BYOND_VERSION_MINOR) {
+				(..=515, _) | (516, ..=1667) => Self::bytecode_offset_pre1668,
+				_ => Self::bytecode_offset_post1668,
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn bytecode_offset_pre1668(this: &Self) -> u16 {
+		unsafe { this.pre1668.bytecode_offset }
+	}
+
+	#[inline(never)]
+	fn bytecode_offset_post1668(this: &Self) -> u16 {
+		unsafe { this.post1668.bytecode_offset }
+	}
+
+	pub fn dot(&self) -> values::Value {
+		static REDIRECT: OnceLock<fn(&ExecutionContext) -> values::Value> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match (crate::version::BYOND_VERSION_MAJOR, crate::version::BYOND_VERSION_MINOR) {
+				(..=515, _) | (516, ..=1667) => Self::dot_pre1668,
+				_ => Self::dot_post1668,
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn dot_pre1668(this: &Self) -> values::Value {
+		unsafe { this.pre1668.dot }
+	}
+
+	#[inline(never)]
+	fn dot_post1668(this: &Self) -> values::Value {
+		unsafe { this.post1668.dot }
+	}
+
+	pub fn dot_ptr(&mut self) -> *mut values::Value {
+		static REDIRECT: OnceLock<fn(&mut ExecutionContext) -> *mut values::Value> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match (crate::version::BYOND_VERSION_MAJOR, crate::version::BYOND_VERSION_MINOR) {
+				(..=515, _) | (516, ..=1667) => Self::dot_ptr_pre1668,
+				_ => Self::dot_ptr_post1668,
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn dot_ptr_pre1668(this: &mut Self) -> *mut values::Value {
+		unsafe { &mut this.pre1668.dot as *mut values::Value }
+	}
+
+	#[inline(never)]
+	fn dot_ptr_post1668(this: &mut Self) -> *mut values::Value {
+		unsafe { &mut this.post1668.dot as *mut values::Value }
+	}
+
+	pub fn locals(&self) -> *mut values::Value {
+		static REDIRECT: OnceLock<fn(&ExecutionContext) -> *mut values::Value> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match (crate::version::BYOND_VERSION_MAJOR, crate::version::BYOND_VERSION_MINOR) {
+				(..=515, _) | (516, ..=1667) => Self::locals_pre1668,
+				_ => Self::locals_post1668,
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn locals_pre1668(this: &Self) -> *mut values::Value {
+		unsafe { this.pre1668.locals }
+	}
+
+	#[inline(never)]
+	fn locals_post1668(this: &Self) -> *mut values::Value {
+		unsafe { this.post1668.locals }
+	}
+
+	pub fn locals_count(&self) -> u16 {
+		static REDIRECT: OnceLock<fn(&ExecutionContext) -> u16> = OnceLock::new();
+		REDIRECT.get_or_init(|| unsafe {
+			match (crate::version::BYOND_VERSION_MAJOR, crate::version::BYOND_VERSION_MINOR) {
+				(..=515, _) | (516, ..=1667) => Self::locals_count_pre1668,
+				_ => Self::locals_count_post1668,
+			}
+		})(self)
+	}
+
+	#[inline(never)]
+	fn locals_count_pre1668(this: &Self) -> u16 {
+		unsafe { this.pre1668.locals_count }
+	}
+
+	#[inline(never)]
+	fn locals_count_post1668(this: &Self) -> u16 {
+		unsafe { this.post1668.locals_count }
+	}
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ExecutionContextPre1668 {
+	pub proc_instance: *mut ProcInstance,
+	pub parent_context: *mut ExecutionContext,
+	pub filename: strings::StringId,
+	pub line: u32,
+	pub bytecode: *mut u32,
+	pub bytecode_offset: u16,
+	test_flag: u8,
+	unk_0: u8,
+	cached_datum: values::Value,
+	unk_1: [u8; 0x10],
+	pub dot: values::Value,
+	pub locals: *mut values::Value,
+	stack: *mut values::Value,
+	pub locals_count: u16,
+	stack_size: u16,
+	unk_2: u32,
+	current_iterator: *mut values::Value,
+	iterator_allocated: u32,
+	iterator_length: u32,
+	iterator_index: u32,
+	unk_3: u32,
+	unk_4: [u8; 0x03],
+	iterator_filtered_type: u8,
+	unk_5: u8,
+	unk_6: u8,
+	unk_7: u8,
+	infinite_loop_count: u32,
+	unk_8: [u8; 0x02],
+	paused: u8,
+	unk_9: [u8; 0x33],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ExecutionContextPost1668 {
 	pub proc_instance: *mut ProcInstance,
 	pub parent_context: *mut ExecutionContext,
 	pub filename: strings::StringId,

--- a/auxtools/src/raw_types/procs.rs
+++ b/auxtools/src/raw_types/procs.rs
@@ -215,7 +215,7 @@ pub struct ExecutionContext {
 	test_flag: u8,
 	unk_0: u8,
 	cached_datum: values::Value,
-	unk_1: [u8; 0x10],
+	unk_1: [u8; 0x14],
 	pub dot: values::Value,
 	pub locals: *mut values::Value,
 	stack: *mut values::Value,

--- a/auxtools/src/raw_types/values.rs
+++ b/auxtools/src/raw_types/values.rs
@@ -30,6 +30,13 @@ pub enum ValueTag {
 	AreaContents = 0x19,
 	WorldContents = 0x1A,
 	ObjContents = 0x1C,
+
+	DatumTypepath = 0x20,
+	Datum = 0x21,
+	SaveFile = 0x23,
+	ProcRef = 0x26,
+	File = 0x27,
+	Number = 0x2A,
 	MobVars = 0x2C,
 	ObjVars = 0x2D,
 	TurfVars = 0x2E,
@@ -44,6 +51,8 @@ pub enum ValueTag {
 	TurfUnderlays = 0x37,
 	AreaOverlays = 0x38,
 	AreaUnderlays = 0x39,
+	Appearance = 0x3A,
+	Pointer = 0x3C,
 	ImageOverlays = 0x40,
 	ImageUnderlays = 0x41,
 	ImageVars = 0x42,
@@ -55,13 +64,12 @@ pub enum ValueTag {
 	MobVisLocs = 0x50,
 	WorldVars = 0x51,
 	GlobalVars = 0x52,
+	Filters = 0x53,
 	ImageVisContents = 0x54,
-
-	Datum = 0x21,
-	SaveFile = 0x23,
-
-	Number = 0x2A,
-	Appearance = 0x3A
+	Alist = 0x55,
+	PixLoc = 0x56,
+	Vector = 0x57,
+	Callee = 0x58
 }
 
 impl fmt::Display for Value {

--- a/debug_server/Cargo.toml
+++ b/debug_server/Cargo.toml
@@ -20,7 +20,7 @@ bincode = "1"
 clap = "3"
 dmasm = { workspace = true }
 region = "3"
-detour = { workspace = true }
+retour = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winuser", "libloaderapi", "errhandlingapi"] }

--- a/debug_server/src/mem_profiler.rs
+++ b/debug_server/src/mem_profiler.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use auxtools::{raw_types::procs::ProcId, *};
-use detour::RawDetour;
+use retour::RawDetour;
 
 static mut THREAD_ID: u32 = 0;
 static MALLOC_SYMBOL: &[u8] = b"malloc\0";

--- a/debug_server/src/mem_profiler.rs
+++ b/debug_server/src/mem_profiler.rs
@@ -227,7 +227,7 @@ impl State {
 				return None;
 			}
 
-			let instance = (*ctx).proc_instance;
+			let instance = (*ctx).proc_instance();
 			if instance.is_null() {
 				return None;
 			}

--- a/debug_server/src/server.rs
+++ b/debug_server/src/server.rs
@@ -843,8 +843,9 @@ impl Server {
 						unsafe {
 							match slot {
 								ArgType::Dot => {
-									let _ = Value::from_raw_owned((*ctx).dot);
-									(*ctx).dot = value.raw;
+									let dot_ptr = (*ctx).dot_ptr();
+									let _ = Value::from_raw_owned(*dot_ptr);
+									*dot_ptr = value.raw;
 								}
 								ArgType::Usr => {
 									let _ = Value::from_raw_owned((*instance).usr);
@@ -861,7 +862,7 @@ impl Server {
 									(*arg) = value.raw;
 								}
 								ArgType::Local(idx) => {
-									let locals = (*ctx).locals;
+									let locals = (*ctx).locals();
 									let local = locals.add(*idx as usize);
 									let _ = Value::from_raw_owned(*local);
 									(*local) = value.raw;
@@ -1065,8 +1066,8 @@ impl Server {
 
 		// Exit now if this is a conditional breakpoint and the condition doesn't pass!
 		if reason == BreakpointReason::Breakpoint {
-			let proc = unsafe { (*(*_ctx).proc_instance).proc };
-			let offset = unsafe { (*_ctx).bytecode_offset };
+			let proc = unsafe { (*(*_ctx).proc_instance()).proc };
+			let offset = unsafe { (*_ctx).bytecode_offset() };
 			let condition = self.conditional_breakpoints.get(&(proc, offset)).cloned();
 
 			if let Some(condition) = condition {

--- a/instruction_hooking/Cargo.toml
+++ b/instruction_hooking/Cargo.toml
@@ -14,7 +14,7 @@ cc = "1.0"
 [dependencies]
 auxtools = { path = "../auxtools" }
 dmasm = { workspace = true }
-detour = { version = "0.8", default-features = false }
+retour = { workspace = true }
 symbolic-common = "12"
 symbolic-demangle = { version = "12", default-features = false }
 

--- a/instruction_hooking/src/lib.rs
+++ b/instruction_hooking/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod disassemble_env;
 
 use auxtools::*;
-use detour::RawDetour;
+use retour::RawDetour;
 use std::{any::Any, cell::UnsafeCell, ffi::c_void};
 
 #[cfg(windows)]


### PR DESCRIPTION
Swaps the detour library to retour, which is just an updated fork of the ancient detour library which finally broke on latest stable Rust.
Updates the ExecutionContext to latest 516 structure.
Updates dmasm to latest, which adds 516 instructions.
Adds several missing value types, borrowed from Meowtonin. (Thanks @ZeWaka, https://github.com/willox/auxtools/pull/101)

**Do not merge.** ExecutionContext needs refactoring to be made into a versioned union, similar to other types, otherwise older version compat will blow up immediately.